### PR TITLE
feat(STADTPULS-496): function for user records count

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "config:base"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
+
 {
+   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "@inpyjamas"
+  ],
+    "baseBranches": [
+    "staging" 
   ]
 }

--- a/supabase-docker-compose/dockerfiles/postgres/docker-entrypoint-initdb.d/50-remote-procedure-calls.sql
+++ b/supabase-docker-compose/dockerfiles/postgres/docker-entrypoint-initdb.d/50-remote-procedure-calls.sql
@@ -35,11 +35,11 @@ $$;
 -- select * from public.get_user_records_count ('46d0c09b-3af6-4452-9392-230672c85929');
 
 CREATE OR REPLACE FUNCTION public.get_user_records_count(selected_user_id uuid)
-  RETURNS table(count bigint)
+  RETURNS  bigint
   LANGUAGE plpgsql AS
 $$
 BEGIN
-    RETURN QUERY(
+    RETURN (
     SELECT COUNT(*) FROM public.records
     WHERE sensor_id IN (
       SELECT id FROM public.sensors WHERE user_id = selected_user_id

--- a/supabase-docker-compose/dockerfiles/postgres/docker-entrypoint-initdb.d/50-remote-procedure-calls.sql
+++ b/supabase-docker-compose/dockerfiles/postgres/docker-entrypoint-initdb.d/50-remote-procedure-calls.sql
@@ -34,15 +34,15 @@ $$;
 -- usage
 -- select * from public.get_user_records_count ('46d0c09b-3af6-4452-9392-230672c85929');
 
-CREATE OR REPLACE FUNCTION public.get_user_records_count(selected_user_id uuid)
+CREATE OR REPLACE FUNCTION public.get_user_records_count(user_id uuid)
   RETURNS  bigint
   LANGUAGE plpgsql AS
 $$
 BEGIN
     RETURN (
-    SELECT COUNT(*) FROM public.records
-    WHERE sensor_id IN (
-      SELECT id FROM public.sensors WHERE user_id = selected_user_id
+    SELECT COUNT(*) FROM public.records as r
+    WHERE r.sensor_id IN (
+      SELECT id FROM public.sensors as s WHERE s.user_id = $1
     ));
 END;
 $$;

--- a/supabase-docker-compose/dockerfiles/postgres/docker-entrypoint-initdb.d/50-remote-procedure-calls.sql
+++ b/supabase-docker-compose/dockerfiles/postgres/docker-entrypoint-initdb.d/50-remote-procedure-calls.sql
@@ -12,7 +12,11 @@ delete from auth.users
 where id = auth.uid();
 $$;
 
--- get users alphabetically (case-insensitively!)
+-- -- get users alphabetically (case-insensitively!)
+-- to remove it run
+-- drop function public.get_users_alphabetically();
+-- usage
+-- select * from public.get_users_alphabetically();
 CREATE OR REPLACE FUNCTION public.get_users_alphabetically()
   RETURNS SETOF public.user_profiles
   LANGUAGE plpgsql AS
@@ -24,15 +28,21 @@ END;
 $$;
 
 -- get records count for individual user
+
+-- to destroy it run
+-- drop function public.get_user_records_count(selected_user_id uuid);
+-- usage
+-- select * from public.get_user_records_count ('46d0c09b-3af6-4452-9392-230672c85929');
+
 CREATE OR REPLACE FUNCTION public.get_user_records_count(selected_user_id uuid)
-  RETURNS integer
+  RETURNS table(count bigint)
   LANGUAGE plpgsql AS
 $$
 BEGIN
-    RETURN QUERY
+    RETURN QUERY(
     SELECT COUNT(*) FROM public.records
     WHERE sensor_id IN (
       SELECT id FROM public.sensors WHERE user_id = selected_user_id
-    );
+    ));
 END;
 $$;

--- a/supabase-docker-compose/dockerfiles/postgres/docker-entrypoint-initdb.d/50-remote-procedure-calls.sql
+++ b/supabase-docker-compose/dockerfiles/postgres/docker-entrypoint-initdb.d/50-remote-procedure-calls.sql
@@ -22,3 +22,17 @@ BEGIN
    SELECT * FROM public.user_profiles ORDER BY lower(name);
 END;
 $$;
+
+-- get records count for individual user
+CREATE OR REPLACE FUNCTION public.get_user_records_count(selected_user_id uuid)
+  RETURNS integer
+  LANGUAGE plpgsql AS
+$$
+BEGIN
+    RETURN QUERY
+    SELECT COUNT(*) FROM public.records
+    WHERE sensor_id IN (
+      SELECT id FROM public.sensors WHERE user_id = selected_user_id
+    );
+END;
+$$;


### PR DESCRIPTION
WIP

---

This PR introduces a function for retrieving the records count for an individual user. This allows for a fast and **correct** count that was not possible due to row limitations in Supabase, see STADTPULS-496 for details.

Once this function is applied, we can retrieve the count with something like:

```js
const { data: count, error } = await supabase
  .rpc('get_user_records_count', { user_id: <SOME_USER_ID> })
```

The parameter `selected_user_id` feels a bit clunky, however `user_id` and `id` were both clashing with other parts of the query. If there is a better way to do this, I'm happy about feedback.

---

(That `renovate.json` is there because I started a branch from `main`.)